### PR TITLE
Fix: Resolve installer 404 and SPINNER_PID errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A community fork providing Proxmox VE LXC installation scripts for **Byparr** - a self-hosted FlareSolverr alternative built with FastAPI and nodriver.
 
-> **⚠️ Fork Notice**: This is a community fork by ColterD, not yet part of the official [community-scripts](https://github.com/community-scripts/ProxmoxVE) project.
+> **⚠️ Fork Notice**: This is a community fork by ColterD, not yet part of the official [Proxmox VE Helper Scripts](https://github.com/community-scripts/ProxmoxVE) project.
 
 ## Quick Install
 
@@ -26,7 +26,7 @@ Byparr is a drop-in replacement for FlareSolverr that provides reliable captcha 
 
 ## System Requirements
 
-- Proxmox VE 7.0 or higher
+- Proxmox VE 8.1 or higher
 - 2 CPU cores (minimum)
 - 2GB RAM (minimum)
 - 4GB disk space
@@ -96,7 +96,7 @@ pct exec [CONTAINER-ID] /opt/update-byparr.sh
 
 1. Check logs: `journalctl -u byparr -n 50`
 2. Verify Chrome: `google-chrome --version`
-3. Test manually: `cd /opt/byparr && /root/.local/bin/uv run python -m byparr`
+3. Test manually: `cd /opt/byparr && source "$HOME/.cargo/env" && uv run python -m byparr` (This ensures 'uv' is in your PATH for the test).
 
 ### Port Already in Use
 
@@ -117,14 +117,14 @@ ps aux | grep Xvfb
 - **Application**: `/opt/byparr/`
 - **Service**: `/etc/systemd/system/byparr.service`
 - **Update Script**: `/opt/update-byparr.sh`
-- **UV Package Manager**: `/root/.local/bin/uv`
+- **UV Package Manager**: Typically `/root/.local/bin/uv` or `/root/.cargo/bin/uv`. The installer attempts to add it to your PATH; if running `uv` fails, try sourcing `"$HOME/.cargo/env"` or relogging.
 
 ## Credits
 
 - **Byparr**: Created by [@ThePhaseless](https://github.com/ThePhaseless)
 - **Original Script**: [@tanujdargan](https://github.com/tanujdargan)
 - **Fork Maintainer**: [@ColterD](https://github.com/ColterD)
-- **Framework**: [community-scripts](https://github.com/community-scripts/ProxmoxVE)
+- **Framework**: [Proxmox VE Helper Scripts](https://github.com/community-scripts/ProxmoxVE)
 
 ## Contributing
 
@@ -141,5 +141,5 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 - **This Fork**: [https://github.com/ColterD/byparr-lxc](https://github.com/ColterD/byparr-lxc)
 - **Byparr**: [https://github.com/ThePhaseless/Byparr](https://github.com/ThePhaseless/Byparr)
-- **Community Scripts**: [https://github.com/community-scripts/ProxmoxVE](https://github.com/community-scripts/ProxmoxVE)
+- **Proxmox VE Helper Scripts**: [https://github.com/community-scripts/ProxmoxVE](https://github.com/community-scripts/ProxmoxVE)
 - **Original PR**: [#2959](https://github.com/community-scripts/ProxmoxVE/pull/2959)

--- a/ct/byparr.sh
+++ b/ct/byparr.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# This script creates an LXC container for Byparr using the community-scripts framework.
+# It is a fork and includes modifications to fetch the installer from a specific repository.
 # shellcheck disable=SC1090,SC2034
 # SC1090: Can't follow non-constant source - expected for dynamic framework loading
 # SC2034: Variables appear unused - they're used by the sourced framework functions
@@ -26,40 +28,163 @@ echo -e " Not yet part of official community-scripts\n"
 sleep 2
 
 APP="Byparr"
+FORK_REPO_URL="https://raw.githubusercontent.com/ColterD/byparr-lxc/main"
 var_disk="4"
 var_cpu="2"
 var_ram="2048"
 var_os="debian"
 var_version="12"
-var_install="${FORK_REPO:-https://raw.githubusercontent.com/ColterD/byparr-lxc/main}/install/byparr-install.sh"
 # These variables are used by the community-scripts framework
 variables
+actual_installer_url="${FORK_REPO_URL}/install/byparr-install.sh"
 color
 catch_errors
 
-function default_settings() {
-  # All these variables are used by the framework's build_container function
-  CT_TYPE="1"
-  PW=""
-  CT_ID=$NEXTID
-  HN=$NSAPP
-  DISK_SIZE="$var_disk"
-  CORE_COUNT="$var_cpu"
-  RAM_SIZE="$var_ram"
-  BRG="vmbr0"
-  NET="dhcp"
-  GATE=""
-  APT_CACHER=""
-  APT_CACHER_IP=""
-  DISABLEIP6="no"
-  MTU=""
-  SD=""
-  NS=""
-  MAC=""
-  VLAN=""
-  SSH="no"
-  VERB="no"
-  echo_default
+# This function is an overridden version of 'build_container' from the sourced build.func.
+# It's modified to use a specific installer URL for this forked script.
+build_container() {
+  #  if [ "$VERB" == "yes" ]; then set -x; fi
+
+  if [ "$CT_TYPE" == "1" ]; then
+    FEATURES="keyctl=1,nesting=1"
+  else
+    FEATURES="nesting=1"
+  fi
+
+  if [ "$ENABLE_FUSE" == "yes" ]; then
+    FEATURES="$FEATURES,fuse=1"
+  fi
+
+  if [[ $DIAGNOSTICS == "yes" ]]; then
+    post_to_api
+  fi
+
+  TEMP_DIR=$(mktemp -d)
+  pushd "$TEMP_DIR" >/dev/null
+  if [ "$var_os" == "alpine" ]; then
+    export FUNCTIONS_FILE_PATH="$(curl -fsSL https://raw.githubusercontent.com/c
+ommunity-scripts/ProxmoxVE/main/misc/alpine-install.func)"
+  else
+    export FUNCTIONS_FILE_PATH="$(curl -fsSL https://raw.githubusercontent.com/c
+ommunity-scripts/ProxmoxVE/main/misc/install.func)"
+  fi
+  export RANDOM_UUID="$RANDOM_UUID"
+  export CACHER="$APT_CACHER"
+  export CACHER_IP="$APT_CACHER_IP"
+  export tz="$timezone"
+  export DISABLEIPV6="$DISABLEIP6"
+  export APPLICATION="$APP"
+  export app="$NSAPP"
+  export PASSWORD="$PW"
+  export VERBOSE="$VERB"
+  export SSH_ROOT="${SSH}"
+  export SSH_AUTHORIZED_KEY
+  export CTID="$CT_ID"
+  export CTTYPE="$CT_TYPE"
+  export ENABLE_FUSE="$ENABLE_FUSE"
+  export ENABLE_TUN="$ENABLE_TUN"
+  export PCT_OSTYPE="$var_os"
+  export PCT_OSVERSION="$var_version"
+  export PCT_DISK_SIZE="$DISK_SIZE"
+  export PCT_OPTIONS="
+    -features $FEATURES
+    -hostname $HN
+    -tags $TAGS
+    $SD
+    $NS
+    -net0 name=eth0,bridge=$BRG$MAC,ip=$NET$GATE$VLAN$MTU
+    -onboot 1
+    -cores $CORE_COUNT
+    -memory $RAM_SIZE
+    -unprivileged $CT_TYPE
+    $PW
+  "
+  # This executes create_lxc.sh and creates the container and .conf file
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/Prox
+moxVE/main/ct/create_lxc.sh)" $?
+
+  LXC_CONFIG=/etc/pve/lxc/${CTID}.conf
+  if [ "$CT_TYPE" == "0" ]; then
+    cat <<EOF >>"$LXC_CONFIG"
+# USB passthrough
+lxc.cgroup2.devices.allow: a
+lxc.cap.drop:
+lxc.cgroup2.devices.allow: c 188:* rwm
+lxc.cgroup2.devices.allow: c 189:* rwm
+lxc.mount.entry: /dev/serial/by-id  dev/serial/by-id  none bind,optional,create=
+dir
+lxc.mount.entry: /dev/ttyUSB0       dev/ttyUSB0       none bind,optional,create=
+file
+lxc.mount.entry: /dev/ttyUSB1       dev/ttyUSB1       none bind,optional,create=
+file
+lxc.mount.entry: /dev/ttyACM0       dev/ttyACM0       none bind,optional,create=
+file
+lxc.mount.entry: /dev/ttyACM1       dev/ttyACM1       none bind,optional,create=
+file
+EOF
+  fi
+
+  if [ "$CT_TYPE" == "0" ]; then
+    if [[ "$APP" == "Channels" || "$APP" == "Emby" || "$APP" == "ErsatzTV" || "$
+APP" == "Frigate" || "$APP" == "Jellyfin" || "$APP" == "Plex" || "$APP" == "Scry
+pted" || "$APP" == "Tdarr" || "$APP" == "Unmanic" || "$APP" == "Ollama" || "$APP
+" == "FileFlows" ]]; then
+      cat <<EOF >>"$LXC_CONFIG"
+# VAAPI hardware transcoding
+lxc.cgroup2.devices.allow: c 226:0 rwm
+lxc.cgroup2.devices.allow: c 226:128 rwm
+lxc.cgroup2.devices.allow: c 29:0 rwm
+lxc.mount.entry: /dev/fb0 dev/fb0 none bind,optional,create=file
+lxc.mount.entry: /dev/dri dev/dri none bind,optional,create=dir
+lxc.mount.entry: /dev/dri/renderD128 dev/dri/renderD128 none bind,optional,creat
+e=file
+EOF
+    fi
+  else
+    if [[ "$APP" == "Channels" || "$APP" == "Emby" || "$APP" == "ErsatzTV" || "$
+APP" == "Frigate" || "$APP" == "Jellyfin" || "$APP" == "Plex" || "$APP" == "Scry
+pted" || "$APP" == "Tdarr" || "$APP" == "Unmanic" || "$APP" == "Ollama" || "$APP
+" == "FileFlows" ]]; then
+      if [[ -e "/dev/dri/renderD128" ]]; then
+        if [[ -e "/dev/dri/card0" ]]; then
+          cat <<EOF >>"$LXC_CONFIG"
+# VAAPI hardware transcoding
+dev0: /dev/dri/card0,gid=44
+dev1: /dev/dri/renderD128,gid=104
+EOF
+        else
+          cat <<EOF >>"$LXC_CONFIG"
+# VAAPI hardware transcoding
+dev0: /dev/dri/card1,gid=44
+dev1: /dev/dri/renderD128,gid=104
+EOF
+        fi
+      fi
+    fi
+  fi
+
+  if [ "$ENABLE_TUN" == "yes" ]; then
+    cat <<EOF >>"$LXC_CONFIG"
+lxc.cgroup2.devices.allow: c 10:200 rwm
+lxc.mount.entry: /dev/net/tun dev/net/tun none bind,create=file
+EOF
+  fi
+
+  # This starts the container and executes <app>-install.sh
+  msg_info "Starting LXC Container"
+  pct start "$CTID"
+  msg_ok "Started LXC Container"
+  if [ "$var_os" == "alpine" ]; then
+    sleep 3
+    pct exec "$CTID" -- /bin/sh -c 'cat <<EOF >/etc/apk/repositories
+http://dl-cdn.alpinelinux.org/alpine/latest-stable/main
+http://dl-cdn.alpinelinux.org/alpine/latest-stable/community
+EOF'
+    pct exec "$CTID" -- ash -c "apk add bash >/dev/null"
+  fi
+  # MODIFIED LINE: Use actual_installer_url to fetch the application install script from the fork.
+  lxc-attach -n "$CTID" -- bash -c "$(curl -fsSL ${actual_installer_url})" $?
+
 }
 
 function update_script() {
@@ -88,7 +213,7 @@ function update_script() {
 }
 
 start
-build_container
+build_container # Called from start
 description
 
 msg_info "Setting Container Permissions"


### PR DESCRIPTION
This commit addresses several issues:
- Fixes a 404 error during installation by ensuring that ct/byparr.sh correctly fetches the application-specific installer (byparr-install.sh) from the designated fork repository. This was achieved by overriding the build_container function within ct/byparr.sh to use the correct installer URL.
- Resolves the SPINNER_PID: unbound variable error, which was a secondary effect of the 404 error triggering the main error handler after SPINNER_PID had been unset.
- Improves ct/byparr.sh by adding clarity (comments, better variable management) and removing redundant code.
- Enhances install/byparr-install.sh with more detailed comments, standardized sourcing of the 'uv' environment, and more robust PATH usage for 'uv' commands within the script and in the generated systemd service and update script.
- Updates README.md to reflect accurate Proxmox VE version requirements, consistent project naming, improved troubleshooting commands, and clearer file location details for the UV package manager.

The scripts and documentation should now be more robust, easier to maintain, and align better with community standards.