### PR TITLE
Fix: Resolve SPINNER_PID unbound variable error in byparr-install.sh

### DIFF
--- a/install/byparr-install.sh
+++ b/install/byparr-install.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-declare SPINNER_PID=""
+declare -g SPINNER_PID=""
+export SPINNER_PID
 
 # Copyright (c) 2025 ColterD (Colter Dahlberg)
 # Author: ColterD (Colter Dahlberg)  


### PR DESCRIPTION
The byparr-install.sh script was encountering an "unbound variable" error for SPINNER_PID. This occurred because SPINNER_PID was declared locally but accessed by functions within the sourced install.func script, especially when 'set -u' was active.

This commit changes the declaration of SPINNER_PID in install/byparr-install.sh to `declare -g SPINNER_PID=""` and adds `export SPINNER_PID` to make it a global and exported variable. This ensures its availability to sourced scripts and their functions, preventing the unbound variable error.