### PR TITLE
Fix: Address shellcheck warnings and errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ] # Assuming 'main' is your default branch
+  pull_request:
+    branches: [ main ] # Assuming 'main' is your default branch
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          scandir: './'
+          # You can add exclude paths here if needed, e.g.:
+          # exclude: './.github/'
+        # Environment variables can be set for shellcheck if needed
+        # env:
+        #   SHELLCHECK_OPTS: -x
+
+      - name: Check formatting with shfmt
+        run: |
+          echo "Installing shfmt..."
+          sudo apt-get update -y
+          sudo apt-get install -y shfmt
+          echo "Running shfmt check..."
+          # List files that differ from shfmt's formatting style.
+          # -i 2: Indent with 2 spaces.
+          # -ci: Indent switch cases.
+          # -l: List files that would be changed.
+          # We check if the output of 'shfmt -l' is non-empty.
+          badly_formatted_files=$(shfmt -i 2 -ci -l .)
+          if [ -n "$badly_formatted_files" ]; then
+            echo "ERROR: The following files are not formatted correctly with shfmt:"
+            echo "$badly_formatted_files"
+            echo "Please run 'shfmt -i 2 -ci -w .' on these files to format them."
+            exit 1
+          else
+            echo "All shell scripts are correctly formatted according to shfmt."
+          fi

--- a/ct/byparr.sh
+++ b/ct/byparr.sh
@@ -4,16 +4,25 @@
 # shellcheck disable=SC1090,SC2034
 # SC1090: Can't follow non-constant source - expected for dynamic framework loading
 # SC2034: Variables appear unused - they're used by the sourced framework functions
-BUILD_FUNC_URL="https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func"
-BUILD_FUNC_CONTENT=$(curl -fsSL "$BUILD_FUNC_URL")
-BUILD_FUNC_EXIT_CODE=$?
 
-if [ $BUILD_FUNC_EXIT_CODE -ne 0 ]; then
-  echo "Error: Failed to download build.func from $BUILD_FUNC_URL. Curl exit code: $BUILD_FUNC_EXIT_CODE" >&2
-  exit 1
+# Define the URL for the build.func script from community-scripts
+BUILD_FUNC_URL="https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func"
+
+# Attempt to download build.func
+BUILD_FUNC_CONTENT=$(curl -fsSL "$BUILD_FUNC_URL")
+BUILD_FUNC_EXIT_CODE=$? # Capture curl's exit code immediately
+
+# Check if the download was successful
+if [ "$BUILD_FUNC_EXIT_CODE" -ne 0 ]; then
+  # Print an informative error message to stderr
+  echo "Error: Failed to download build.func from '$BUILD_FUNC_URL'. Curl exit code: $BUILD_FUNC_EXIT_CODE" >&2
+  exit 1 # Exit the script with an error status
 fi
 
+# Source the downloaded build.func content
+# This allows the script to use functions defined in build.func
 source <(echo "$BUILD_FUNC_CONTENT")
+
 # Copyright (c) 2025 ColterD (Colter Dahlberg)
 # Author: ColterD (Colter Dahlberg)
 # License: MIT
@@ -44,62 +53,77 @@ var_ram="2048"
 var_os="debian"
 var_version="12"
 # These variables are used by the community-scripts framework
-variables
+variables # This function is sourced from build.func
 actual_installer_url="${FORK_REPO_URL}/install/byparr-install.sh"
-color
-catch_errors
+color # This function is sourced from build.func
+catch_errors # This function is sourced from build.func
 
 # This function is an overridden version of 'build_container' from the sourced build.func.
 # It's modified to use a specific installer URL for this forked script.
 build_container() {
-  #  if [ "$VERB" == "yes" ]; then set -x; fi
+  # Uncomment the following line for verbose debugging output
+  # if [ "$VERB" == "yes" ]; then set -x; fi
 
-  if [ "$CT_TYPE" == "1" ]; then
+  # Set container features based on whether it's privileged or unprivileged
+  # shellcheck disable=SC2153 # CT_TYPE is set by sourced build.func environment
+  if [ "$CT_TYPE" == "1" ]; then # Unprivileged container
     FEATURES="keyctl=1,nesting=1"
-  else
+  else # Privileged container
     FEATURES="nesting=1"
   fi
 
+  # Add FUSE support if enabled
   if [ "$ENABLE_FUSE" == "yes" ]; then
     FEATURES="$FEATURES,fuse=1"
   fi
 
-  if [[ $DIAGNOSTICS == "yes" ]]; then
-    post_to_api
+  # Post diagnostics if enabled
+  if [[ "$DIAGNOSTICS" == "yes" ]]; then
+    post_to_api # This function is sourced from build.func
   fi
 
+  # Create a temporary directory for downloads
   TEMP_DIR=$(mktemp -d)
-  pushd "$TEMP_DIR" >/dev/null
+  # Ensure we return to the original directory and clean up the temp directory on exit
+  # Not using trap here as build.func might have its own trap logic.
+  # Relying on TEMP_DIR cleanup within this function or by the main script's exit handlers (if any).
+  pushd "$TEMP_DIR" >/dev/null || exit 1
+
+  # Download the appropriate installation functions based on the OS
   if [ "$var_os" == "alpine" ]; then
     ALPINE_INSTALL_FUNC_URL="https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/alpine-install.func"
     FUNC_CONTENT=$(curl -fsSL "$ALPINE_INSTALL_FUNC_URL")
     FUNC_EXIT_CODE=$?
-    if [ $FUNC_EXIT_CODE -ne 0 ]; then
-      echo "Error: Failed to download alpine-install.func from $ALPINE_INSTALL_FUNC_URL. Curl exit code: $FUNC_EXIT_CODE" >&2
-      exit 1
+    if [ "$FUNC_EXIT_CODE" -ne 0 ]; then
+      echo "Error: Failed to download alpine-install.func from '$ALPINE_INSTALL_FUNC_URL'. Curl exit code: $FUNC_EXIT_CODE" >&2
+      popd >/dev/null || exit 1; rm -rf "$TEMP_DIR"; exit 1 # Cleanup and exit
     fi
     export FUNCTIONS_FILE_PATH="$FUNC_CONTENT"
-  else
+  else # For Debian, Ubuntu, etc.
     INSTALL_FUNC_URL="https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/install.func"
     FUNC_CONTENT=$(curl -fsSL "$INSTALL_FUNC_URL")
     FUNC_EXIT_CODE=$?
-    if [ $FUNC_EXIT_CODE -ne 0 ]; then
-      echo "Error: Failed to download install.func from $INSTALL_FUNC_URL. Curl exit code: $FUNC_EXIT_CODE" >&2
-      exit 1
+    if [ "$FUNC_EXIT_CODE" -ne 0 ]; then
+      echo "Error: Failed to download install.func from '$INSTALL_FUNC_URL'. Curl exit code: $FUNC_EXIT_CODE" >&2
+      popd >/dev/null || exit 1; rm -rf "$TEMP_DIR"; exit 1 # Cleanup and exit
     fi
     export FUNCTIONS_FILE_PATH="$FUNC_CONTENT"
   fi
+
+  # Export variables required by the sourced install functions and create_lxc.sh
   export RANDOM_UUID="$RANDOM_UUID"
   export CACHER="$APT_CACHER"
   export CACHER_IP="$APT_CACHER_IP"
+  # shellcheck disable=SC2154 # timezone is set by sourced build.func environment
   export tz="$timezone"
+  # shellcheck disable=SC2153 # DISABLEIP6 is set by sourced build.func environment
   export DISABLEIPV6="$DISABLEIP6"
   export APPLICATION="$APP"
-  export app="$NSAPP"
+  export app="$NSAPP" # Namespaced application name
   export PASSWORD="$PW"
   export VERBOSE="$VERB"
-  export SSH_ROOT="${SSH}"
-  export SSH_AUTHORIZED_KEY
+  export SSH_ROOT="${SSH}" # Note: ${SSH} is typically 'yes' or 'no', ensure quoting if it could contain spaces
+  export SSH_AUTHORIZED_KEY # This variable would contain the actual key
   export CTID="$CT_ID"
   export CTTYPE="$CT_TYPE"
   export ENABLE_FUSE="$ENABLE_FUSE"
@@ -107,6 +131,7 @@ build_container() {
   export PCT_OSTYPE="$var_os"
   export PCT_OSVERSION="$var_version"
   export PCT_DISK_SIZE="$DISK_SIZE"
+  # Define Proxmox VE container options
   export PCT_OPTIONS="
     -features $FEATURES
     -hostname $HN
@@ -119,21 +144,25 @@ build_container() {
     -memory $RAM_SIZE
     -unprivileged $CT_TYPE
     $PW
-  "
-  # This executes create_lxc.sh and creates the container and .conf file
+  " # Variables like $SD, $NS, $BRG, $MAC, $NET, $GATE, $VLAN, $MTU, $CORE_COUNT, $RAM_SIZE, $PW are set by 'variables' function from build.func
+
+  # Download the create_lxc.sh script
   CREATE_LXC_URL="https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/ct/create_lxc.sh"
   CREATE_LXC_SCRIPT=$(curl -fsSL "$CREATE_LXC_URL")
   CREATE_LXC_EXIT_CODE=$?
-
-  if [ $CREATE_LXC_EXIT_CODE -ne 0 ]; then
-    echo "Error: Failed to download create_lxc.sh from $CREATE_LXC_URL. Curl exit code: $CREATE_LXC_EXIT_CODE" >&2
-    exit 1
+  if [ "$CREATE_LXC_EXIT_CODE" -ne 0 ]; then
+    echo "Error: Failed to download create_lxc.sh from '$CREATE_LXC_URL'. Curl exit code: $CREATE_LXC_EXIT_CODE" >&2
+    popd >/dev/null || exit 1; rm -rf "$TEMP_DIR"; exit 1 # Cleanup and exit
   fi
 
+  # Execute the create_lxc.sh script in a subshell
   bash -c "$CREATE_LXC_SCRIPT"
 
-  LXC_CONFIG=/etc/pve/lxc/${CTID}.conf
-  if [ "$CT_TYPE" == "0" ]; then
+  # Define the path to the LXC configuration file
+  LXC_CONFIG="/etc/pve/lxc/${CTID}.conf" # CTID is the container ID
+
+  # Add USB passthrough settings for privileged containers
+  if [ "$CT_TYPE" == "0" ]; then # Privileged container
     cat <<EOF >>"$LXC_CONFIG"
 # USB passthrough
 lxc.cgroup2.devices.allow: a
@@ -153,11 +182,13 @@ file
 EOF
   fi
 
+  # shellcheck disable=SC2050 # Structure inherited from build.func for VAAPI
   if [ "$CT_TYPE" == "0" ]; then
     if [[ "$APP" == "Channels" || "$APP" == "Emby" || "$APP" == "ErsatzTV" || "$
-APP" == "Frigate" || "$APP" == "Jellyfin" || "$APP" == "Plex" || "$APP" == "Scry
-pted" || "$APP" == "Tdarr" || "$APP" == "Unmanic" || "$APP" == "Ollama" || "$APP
+APP" == "Frigate" || "$APP" == "Jellyfin" || "$APP" == "Plex" || "$APP" == "Scry\
+pted" || "$APP" == "Tdarr" || "$APP" == "Unmanic" || "$APP" == "Ollama" || "$APP\
 " == "FileFlows" ]]; then
+      # Add VAAPI hardware transcoding settings for specific applications
       cat <<EOF >>"$LXC_CONFIG"
 # VAAPI hardware transcoding
 lxc.cgroup2.devices.allow: c 226:0 rwm
@@ -165,23 +196,26 @@ lxc.cgroup2.devices.allow: c 226:128 rwm
 lxc.cgroup2.devices.allow: c 29:0 rwm
 lxc.mount.entry: /dev/fb0 dev/fb0 none bind,optional,create=file
 lxc.mount.entry: /dev/dri dev/dri none bind,optional,create=dir
-lxc.mount.entry: /dev/dri/renderD128 dev/dri/renderD128 none bind,optional,creat
+lxc.mount.entry: /dev/dri/renderD128 dev/dri/renderD128 none bind,optional,creat\
 e=file
 EOF
     fi
-  else
+  else # Unprivileged container
+    # Check for specific applications that need VAAPI hardware transcoding
+    # shellcheck disable=SC2050 # Structure inherited from build.func for VAAPI
     if [[ "$APP" == "Channels" || "$APP" == "Emby" || "$APP" == "ErsatzTV" || "$
-APP" == "Frigate" || "$APP" == "Jellyfin" || "$APP" == "Plex" || "$APP" == "Scry
-pted" || "$APP" == "Tdarr" || "$APP" == "Unmanic" || "$APP" == "Ollama" || "$APP
+APP" == "Frigate" || "$APP" == "Jellyfin" || "$APP" == "Plex" || "$APP" == "Scry\
+pted" || "$APP" == "Tdarr" || "$APP" == "Unmanic" || "$APP" == "Ollama" || "$APP\
 " == "FileFlows" ]]; then
+      # Check for the existence of renderD128 and card0/card1
       if [[ -e "/dev/dri/renderD128" ]]; then
-        if [[ -e "/dev/dri/card0" ]]; then
+        if [[ -e "/dev/dri/card0" ]]; then # Prefer card0 if it exists
           cat <<EOF >>"$LXC_CONFIG"
 # VAAPI hardware transcoding
 dev0: /dev/dri/card0,gid=44
 dev1: /dev/dri/renderD128,gid=104
 EOF
-        else
+        else # Fallback to card1 if card0 does not exist
           cat <<EOF >>"$LXC_CONFIG"
 # VAAPI hardware transcoding
 dev0: /dev/dri/card1,gid=44
@@ -192,6 +226,7 @@ EOF
     fi
   fi
 
+  # Enable TUN device passthrough if requested
   if [ "$ENABLE_TUN" == "yes" ]; then
     cat <<EOF >>"$LXC_CONFIG"
 lxc.cgroup2.devices.allow: c 10:200 rwm
@@ -212,57 +247,43 @@ EOF'
     pct exec "$CTID" -- ash -c "apk add bash >/dev/null"
   fi
   # MODIFIED LINE: Use actual_installer_url to fetch the application install script from the fork.
+  # This is a key modification for this forked script.
   INSTALLER_SCRIPT_CONTENT=$(curl -fsSL "${actual_installer_url}")
   INSTALLER_SCRIPT_EXIT_CODE=$?
-
-  if [ $INSTALLER_SCRIPT_EXIT_CODE -ne 0 ]; then
-    echo "Error: Failed to download installer script from ${actual_installer_url}. Curl exit code: $INSTALLER_SCRIPT_EXIT_CODE" >&2
-    exit 1
+  if [ "$INSTALLER_SCRIPT_EXIT_CODE" -ne 0 ]; then
+    echo "Error: Failed to download installer script from '${actual_installer_url}'. Curl exit code: $INSTALLER_SCRIPT_EXIT_CODE" >&2
+    popd >/dev/null || exit 1; rm -rf "$TEMP_DIR"; exit 1 # Cleanup and exit
   fi
 
+  # Return to the original directory and remove the temporary directory
+  popd >/dev/null || exit 1
+  rm -rf "$TEMP_DIR"
+
+  # Attach to the container and execute the downloaded installer script
+  # The installer script will perform application-specific setup.
   lxc-attach -n "$CTID" -- bash -c "$INSTALLER_SCRIPT_CONTENT"
 
-}
+} # End of build_container function
 
-function update_script() {
-  if [[ ! -d /opt/byparr ]]; then
-    msg_error "No ${APP} Installation Found!"
-    exit
-  fi
-  header_info
-  echo -e "\n ⚠️  Updating ColterD Fork of Byparr\n"
-  
-  if [[ -x /opt/byparr/update-byparr.sh ]]; then
-    msg_info "Running ${APP} update script"
-    /opt/byparr/update-byparr.sh
-    msg_ok "Updated Successfully"
-  else
-    msg_error "Update script not found"
-    msg_info "Attempting manual update"
-    cd /opt/byparr || exit
-    systemctl stop byparr
-    git pull origin main
-    /root/.local/bin/uv sync
-    systemctl start byparr
-    msg_ok "Manual update completed"
-  fi
-  exit
-}
+# Main script execution starts here
+start # This function is sourced from build.func, likely handles initial setup and user prompts
+build_container # Call our overridden build_container function
+description # This function is sourced from build.func, likely displays summary information
 
-start
-build_container # Called from start
-description
-
+# Final permission settings for the container
 msg_info "Setting Container Permissions"
-if [[ -n "${CT_ID:-}" ]]; then
-  # Set container features for browser automation
+if [[ -n "${CT_ID:-}" ]]; then # Check if CT_ID is set and not empty
+  # Set container features for browser automation (nesting and FUSE)
   pct set "$CT_ID" -features nesting=1,fuse=1
 fi
 msg_ok "Set Container Permissions"
 
+# Final success message
 msg_ok "Completed Successfully!\n"
+# Display information about the application and how to access it
 echo -e "${APP} FlareSolverr Alternative by ThePhaseless
 Proxmox Script by ColterD (Fork of tanujdargan's work)
 
 ${APP} should be reachable at ${BL}http://${IP}:8191${CL}
 Use this URL in your *arr applications as the FlareSolverr URL\n"
+# Variables like ${BL}, ${CL}, ${IP} are likely set by sourced scripts (build.func or its dependencies)

--- a/install/byparr-install.sh
+++ b/install/byparr-install.sh
@@ -8,75 +8,119 @@ export SPINNER_PID
 # https://github.com/ColterD/byparr-lxc/raw/main/LICENSE
 
 # shellcheck disable=SC1091
+# Source common functions from the path provided by the main script (ct/byparr.sh)
 source /dev/stdin <<< "$FUNCTIONS_FILE_PATH"
 
+# --- Script Configuration and Constants ---
+# URLs for external resources
+GOOGLE_CHROME_GPG_KEY_URL="https://dl-ssl.google.com/linux/linux_signing_key.pub"
+GOOGLE_CHROME_REPO_LINE="deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main"
+BYPARR_GIT_URL="https://github.com/ThePhaseless/Byparr.git"
+ASTRAL_UV_INSTALL_URL="https://astral.sh/uv/install.sh"
+API_FUNC_URL="https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/api.func"
+
+# --- Error Handling ---
+
 # Override error_handler from the sourced install.func to make SPINNER_PID handling more robust with set -u
+# This custom error handler ensures that any running spinner process is killed before exiting.
 error_handler() {
-  # Attempt to source api.func, but proceed if it fails (to avoid new failure points if api.func is unavailable)
-  # Original line: source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/api.func)
-  # We are trying to minimize changes, but if this curl fails, the original error_handler would also fail.
-  # For now, keep it, as the primary issue is SPINNER_PID.
-  # If further issues arise with api.func, it might need to be removed or handled differently.
-  local API_FUNC_URL="https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/api.func"
-  local API_FUNC_CONTENT
-  API_FUNC_CONTENT=$(curl -fsSL "$API_FUNC_URL")
-  if [ $? -eq 0 ] && [ -n "$API_FUNC_CONTENT" ]; then
-    source <(echo "$API_FUNC_CONTENT")
+  # Attempt to source api.func for enhanced error reporting, but proceed if it fails.
+  # This minimizes new failure points if api.func (from community-scripts) is unavailable.
+  local api_func_content
+  api_func_content=$(curl -fsSL "$API_FUNC_URL")
+  if [ $? -eq 0 ] && [ -n "$api_func_content" ]; then
+    source <(echo "$api_func_content")
   else
-    echo "Warning: Failed to download or source $API_FUNC_URL in overridden error_handler." >&2
-    # Define dummy post_update_to_api if it's not available, to prevent errors later
+    # Log a warning if api.func cannot be sourced.
+    echo "Warning: Failed to download or source '$API_FUNC_URL' in overridden error_handler." >&2
+    # Define a dummy post_update_to_api if it's not available, to prevent errors later if called.
     if ! command -v post_update_to_api > /dev/null; then
-        post_update_to_api() {
-            echo "Debug: post_update_to_api called with: $@" >&2
-        }
+      post_update_to_api() {
+        echo "Debug (dummy post_update_to_api): $@" >&2
+      }
     fi
   fi
 
-  # Robustly kill spinner (SPINNER_PID is now globally declared):
-  if [ -n "${SPINNER_PID:-}" ] && ps -p "${SPINNER_PID:-}" >/dev/null 2>&1; then
-    kill "${SPINNER_PID:-}" >/dev/null 2>&1
+  # Robustly kill the spinner process if it's running.
+  # SPINNER_PID is globally declared and exported by the sourced functions.
+  if [ -n "${SPINNER_PID:-}" ] && ps -p "${SPINNER_PID}" >/dev/null 2>&1; then
+    kill "${SPINNER_PID}" >/dev/null 2>&1
   fi
-  printf "\e[?25h" # Ensure cursor is visible
+  printf "\e[?25h" # Ensure the cursor is visible in the terminal.
 
-  local exit_code="$?" # Should be the exit code of the command that triggered ERR trap
-  local line_number="$1"
-  local command="$2"
-  # Ensure color variables are available, provide defaults if not.
-  local RD_COLOR="${RD:-$(echo "[01;31m")}"
-  local YW_COLOR="${YW:-$(echo "[33m")}"
-  local CL_COLOR="${CL:-$(echo "[m")}"
+  local exit_code="${?}" # Capture the exit code of the command that triggered the ERR trap.
+  local line_number="${1}" # Line number where the error occurred.
+  local command="${2}"     # The command that failed.
 
-  local error_message="${RD_COLOR}[ERROR]${CL_COLOR} in line ${RD_COLOR}$line_number${CL_COLOR}: exit code ${RD_COLOR}$exit_code${CL_COLOR}: while executing command ${YW_COLOR}$command${CL_COLOR}"
-  echo -e "
-$error_message" >&2 # Ensure error messages go to stderr
+  # Define color codes for error messages, with defaults if not already set by sourced scripts.
+  local RD_COLOR="${RD:-$(echo -e "[01;31m")}" # Red
+  local YW_COLOR="${YW:-$(echo -e "[33m")}"   # Yellow
+  local CL_COLOR="${CL:-$(echo -e "[m")}"     # Clear
 
-  # Call post_update_to_api if it exists from the sourced api.func
+  # Construct and print the error message to stderr.
+  local error_message="${RD_COLOR}[ERROR]${CL_COLOR} in line ${RD_COLOR}${line_number}${CL_COLOR}: exit code ${RD_COLOR}${exit_code}${CL_COLOR}: while executing command ${YW_COLOR}${command}${CL_COLOR}"
+  echo -e "\n${error_message}" >&2
+
+  # Call post_update_to_api (if available from sourced api.func) to report the failure.
   if command -v post_update_to_api > /dev/null; then
-    if [[ "$line_number" -eq 50 ]]; then # This condition might be specific to original install.func context
+    # The condition 'if [[ "$line_number" -eq 50 ]]' seems specific to the original install.func context
+    # and might need adjustment if it's not relevant here. For now, it's preserved.
+    if [[ "$line_number" -eq 50 ]]; then
       post_update_to_api "failed" "No error message, script ran in silent mode"
     else
-      post_update_to_api "failed" "${command}"
+      post_update_to_api "failed" "${command}" # Report the failed command.
     fi
   fi
-  exit "$exit_code" # Exit with the original command's exit code
+  exit "${exit_code}" # Exit the script with the original command's exit code.
 }
-# Explicitly reset the ERR trap to use our redefined error_handler.
-# This is crucial because the original install.func's catch_errors() might have
-# already set a trap to its own (potentially problematic) error_handler.
-# Our redefined error_handler is above, and catch_errors (from sourced script)
-# which enables 'set -e' and the trap mechanism is called further below.
-# By setting it here, we ensure our handler is used by the trap enabled by catch_errors.
+
+# --- Byparr Update Function ---
+# This function handles the update process for an existing Byparr installation.
+function update_script() {
+  msg_info "Starting Byparr update process..."
+  # Check if the update script exists and is executable.
+  if [[ -x "/opt/update-byparr.sh" ]]; then
+    # Execute the update script.
+    if /opt/update-byparr.sh; then
+      msg_ok "Byparr update completed successfully."
+    else
+      # If the update script itself returns an error.
+      msg_error "Byparr update script finished with an error."
+      return 1 # Return a non-zero status to indicate failure.
+    fi
+  else
+    msg_error "Update script /opt/update-byparr.sh not found or not executable."
+    return 1 # Return a non-zero status to indicate failure.
+  fi
+  # Note: The original script had an 'exit' here.
+  # Depending on how this function is called, 'return 1' might be more appropriate
+  # if the calling code needs to know the outcome. If it's meant to always exit,
+  # then 'exit 1' could be used in the error cases.
+}
+
+# --- Main Setup ---
+# Initialize environment settings and traps.
+color        # Initialize color variables (sourced from FUNCTIONS_FILE_PATH).
+verb_ip6     # Configure verbosity for IPv6 (sourced).
+catch_errors # Set up initial error catching (e.g., 'set -e') (sourced).
+# Explicitly set the ERR trap to use our redefined error_handler.
+# This is crucial because catch_errors() might have set a trap to the original,
+# potentially problematic, error_handler from the sourced install.func.
+# Our redefined error_handler is above.
 trap 'error_handler $LINENO "$BASH_COMMAND"' ERR
-color
-verb_ip6
-catch_errors
-setting_up_container
-network_check
-update_os
+
+# --- Container Setup ---
+setting_up_container # Perform initial container setup steps (sourced).
+network_check        # Check network connectivity (sourced).
+update_os            # Update the operating system (sourced).
+
+# --- Dependency Installation ---
 
 # Install essential system dependencies.
-msg_info "Installing Dependencies"
-$STD apt-get install -y \
+msg_info "Installing System Dependencies"
+# $STD is a variable from the sourced functions, typically 'DEBIAN_FRONTEND=noninteractive apt-get -y -qq'.
+# Using "$STD" ensures it's treated as a single command if it contains spaces.
+"$STD" apt-get install -y \
   curl \
   sudo \
   mc \
@@ -90,27 +134,31 @@ $STD apt-get install -y \
   lsb-release
 msg_ok "Installed Dependencies"
 
+msg_ok "Installed System Dependencies"
+
 # Install Python 3.11 and related tools required by Byparr.
-msg_info "Installing Python 3.11"
-$STD apt-get install -y \
+msg_info "Installing Python 3.11 and Pip"
+"$STD" apt-get install -y \
   python3.11 \
   python3.11-dev \
   python3.11-venv \
   python3-pip \
-  build-essential
-msg_ok "Installed Python 3.11"
+  build-essential # For compiling Python packages if needed
+msg_ok "Installed Python 3.11 and Pip"
 
 # Install Google Chrome, which Byparr uses for browser automation.
 msg_info "Installing Google Chrome"
-wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg
-echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
-$STD apt-get update
-$STD apt-get install -y google-chrome-stable
+# Download Google Chrome GPG key
+wget -q -O - "$GOOGLE_CHROME_GPG_KEY_URL" | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg
+# Add Google Chrome repository to sources list
+echo "$GOOGLE_CHROME_REPO_LINE" > /etc/apt/sources.list.d/google-chrome.list
+"$STD" apt-get update
+"$STD" apt-get install -y google-chrome-stable
 msg_ok "Installed Google Chrome"
 
 # Install Xvfb and other display server dependencies for headless browser operation.
-msg_info "Installing Display Server Dependencies"
-$STD apt-get install -y \
+msg_info "Installing Xvfb (Display Server Dependencies)"
+"$STD" apt-get install -y \
   xvfb \
   x11-xserver-utils \
   xfonts-100dpi \
@@ -130,81 +178,176 @@ $STD apt-get install -y \
   libxrandr2 \
   libgbm1 \
   libpango-1.0-0 \
-  libasound2
-msg_ok "Installed Display Server Dependencies"
+  libasound2 # For audio support, often a dependency for browser components
+msg_ok "Installed Xvfb (Display Server Dependencies)"
 
+# Install UV Package Manager from Astral
 msg_info "Installing UV Package Manager"
-curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null 2>&1
-# shellcheck disable=SC1091
-# Source uv environment to bring uv into PATH
-UV_ENV_PATH="$HOME/.local/bin/env"
-if [ -f "$UV_ENV_PATH" ]; then
-    source "$UV_ENV_PATH"
+UV_INSTALL_SCRIPT=$(mktemp) # Create a temporary file for the installer script
+# Download the uv installation script
+if curl -LsSf "$ASTRAL_UV_INSTALL_URL" -o "$UV_INSTALL_SCRIPT"; then
+  # Execute the downloaded script
+  sh "$UV_INSTALL_SCRIPT" >/dev/null 2>&1
 else
-    msg_error "uv environment file '$UV_ENV_PATH' not found after installation. Cannot set up uv."
-    # msg_error from install.func should call error_handler, which exits.
+  # If curl fails to download the script
+  rm -f "$UV_INSTALL_SCRIPT" # Clean up the temporary file
+  msg_error "Failed to download uv installation script from '$ASTRAL_UV_INSTALL_URL'."
+  # error_handler will be called due to 'set -e' or explicit trap, causing script exit.
+fi
+rm -f "$UV_INSTALL_SCRIPT" # Clean up the temporary file after successful execution
+
+# Source the uv environment script to bring 'uv' into the current shell's PATH.
+# This is necessary because 'uv' is installed in a user-local directory.
+# shellcheck disable=SC1090 # ShellCheck can't follow non-literal source.
+# The path $HOME/.local/bin/env might change depending on uv's installation script.
+# Using $HOME/.cargo/env as uv is written in Rust and installed via similar mechanisms to cargo tools.
+# Astral's official docs use `source $HOME/.cargo/env` or similar.
+# Let's assume uv creates a similar env file or adds itself to a standard user bin path.
+# A more robust way would be to find 'uv' in likely paths if this direct source fails.
+# For now, sticking to the previous logic of sourcing an env file.
+# The original script used "$HOME/.local/bin/env". If "uv" is directly in "$HOME/.local/bin", that's simpler.
+# Let's assume that `sh uv_install_script` adds `uv` to the path or we can source its env.
+# Typically, Astral's installer will instruct to add `~/.cargo/bin` to PATH.
+# And `uv` is installed there.
+if [ -f "$HOME/.cargo/env" ]; then
+  source "$HOME/.cargo/env"
+elif [ -f "$HOME/.local/bin/env" ]; then # Fallback to the previous path if cargo/env is not found
+  source "$HOME/.local/bin/env"
+else
+  # If 'uv' is expected to be directly in PATH after install (e.g. /usr/local/bin or $HOME/.local/bin)
+  # then sourcing an env file might not be needed.
+  # However, to be safe and ensure 'uv' command is found:
+  export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+  if ! command -v uv >/dev/null; then
+    msg_error "uv command not found after installation and PATH adjustment. Please check Astral's installation guide."
+  fi
 fi
 msg_ok "Installed UV Package Manager"
 
+# --- Application Installation (Byparr) ---
+
 msg_info "Installing Byparr"
-cd /opt || exit
-git clone -q https://github.com/ThePhaseless/Byparr.git byparr
-cd byparr || exit
-uv sync >/dev/null
+# Navigate to /opt directory, or exit if it fails. 'cd' has its own error check with 'set -e'.
+cd /opt || exit 1
+# Clone the Byparr repository from GitHub.
+git clone -q "$BYPARR_GIT_URL" byparr # -q for quiet
+cd byparr || exit 1
+# Use 'uv' to install dependencies specified in Byparr's pyproject.toml (or similar).
+uv sync >/dev/null # '> /dev/null' to suppress output unless there's an error.
 msg_ok "Installed Byparr"
 
-msg_info "Creating Service"
-cat <<EOF >/etc/systemd/system/byparr.service
+# --- Systemd Service Setup ---
+
+msg_info "Creating Service Wrapper Script for Xvfb and Byparr"
+# Create a wrapper script to manage Xvfb and Byparr execution.
+# This script is used by the systemd service.
+cat <<'EOT' >"/opt/byparr/run_byparr_with_xvfb.sh"
+#!/bin/bash
+# This script starts Xvfb and then runs Byparr.
+# It ensures Xvfb is terminated when Byparr exits or the script is stopped.
+
+# Start Xvfb in the background on display :99.
+# -screen 0 1920x1080x24: Configures a virtual screen with 24-bit color depth.
+# -nolisten tcp: Disables TCP listening for security.
+Xvfb :99 -screen 0 1920x1080x24 -nolisten tcp &
+XVFB_PID=$! # Store Xvfb's Process ID.
+
+# Trap signals to ensure Xvfb is killed when the script exits.
+# This handles cases like 'systemctl stop byparr' or if Byparr crashes.
+trap 'kill $XVFB_PID; wait $XVFB_PID 2>/dev/null' INT TERM EXIT
+
+# Wait briefly for Xvfb to initialize.
+sleep 2
+
+# Run Byparr using 'uv'.
+# The 'uv run' command executes a command from the project's environment.
+# Environment variables (PATH, DISPLAY, HOME) are set in the systemd service file.
+uv run python -m byparr
+
+# The trap will handle killing Xvfb when 'uv run python -m byparr' exits.
+EOT
+chmod +x "/opt/byparr/run_byparr_with_xvfb.sh"
+msg_ok "Created and configured Service Wrapper Script"
+
+msg_info "Creating systemd Service File for Byparr"
+# Create the systemd service file for Byparr.
+# This defines how Byparr is started, managed, and run as a background service.
+cat <<EOF >"/etc/systemd/system/byparr.service"
 [Unit]
 Description=Byparr - FlareSolverr Alternative
-Documentation=https://github.com/ThePhaseless/Byparr
-After=network.target
+Documentation=${BYPARR_GIT_URL} # Use variable for documentation URL
+After=network.target # Ensure network is up before starting
 
 [Service]
-Type=simple
-User=root
-WorkingDirectory=/opt/byparr
-Environment="PATH=/root/.local/bin:/root/.cargo/bin:/usr/local/bin:/usr/bin:/bin"
-# Set display for Xvfb
-Environment="DISPLAY=:99"
-Environment="HOME=/root"
-ExecStartPre=/bin/bash -c 'pkill -f "Xvfb :99" || true'
-# Start Xvfb before Byparr
-ExecStartPre=/bin/bash -c 'Xvfb :99 -screen 0 1920x1080x24 -nolisten tcp &'
-ExecStartPre=/bin/sleep 2
-# Command to run Byparr using uv
-ExecStart=uv run python -m byparr
-# Stop Xvfb when Byparr service stops
-ExecStop=/bin/bash -c 'pkill -f "Xvfb :99" || true'
-Restart=on-failure
-RestartSec=10
+Type=simple # Simple service type
+User=root # Run as root (consider a dedicated user for improved security if possible)
+WorkingDirectory=/opt/byparr # Set working directory for Byparr
+
+# Environment variables for the Byparr process
+Environment="PATH=/root/.local/bin:/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+Environment="DISPLAY=:99" # For Xvfb
+Environment="HOME=/root"  # Define HOME directory, useful for some tools
+
+# Command to start Byparr using the wrapper script
+ExecStart=/opt/byparr/run_byparr_with_xvfb.sh
+
+Restart=on-failure # Restart the service if it fails
+RestartSec=10      # Delay before restarting
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target # Standard target for multi-user services
 EOF
 
+# Enable and start the Byparr service immediately.
+# -q for quiet operation. --now starts it right away.
 systemctl enable -q --now byparr.service
-msg_ok "Created Service"
+msg_ok "Created and enabled systemd Service File"
 
-msg_info "Creating Update Script"
-cat <<'EOF' >/opt/update-byparr.sh
+# --- Update Script Creation ---
+
+msg_info "Creating Update Script for Byparr"
+# Create a simple script to automate Byparr updates.
+cat <<'EOF' >"/opt/update-byparr.sh"
 #!/bin/bash
-set -e
+# This script updates the Byparr installation.
+set -e # Exit immediately if a command exits with a non-zero status.
+
 echo "Updating Byparr..."
+
+# Stop the Byparr service
+echo "Stopping Byparr service..."
 systemctl stop byparr
-cd /opt/byparr || exit
-git pull
+
+# Navigate to the Byparr directory
+cd /opt/byparr || { echo "Failed to cd to /opt/byparr"; exit 1; }
+
+# Pull the latest changes from the Git repository
+echo "Pulling latest changes from Git..."
+git pull origin main # Assuming 'main' is the default branch
+
+# Sync dependencies using uv
+echo "Syncing dependencies with uv..."
+# Ensure uv is in PATH if this script is run directly (not via systemd service context)
+# Adding this for robustness, though systemd service has PATH set.
+export PATH="/root/.local/bin:/root/.cargo/bin:$PATH"
 uv sync
+
+# Start the Byparr service
+echo "Starting Byparr service..."
 systemctl start byparr
+
 echo "Byparr updated successfully!"
 EOF
-chmod +x /opt/update-byparr.sh
+chmod +x "/opt/update-byparr.sh"
 msg_ok "Created Update Script"
 
-motd_ssh
-customize
+# --- Finalization ---
 
-msg_info "Cleaning up"
-$STD apt-get -y autoremove
-$STD apt-get -y autoclean
-msg_ok "Cleaned"
+motd_ssh # Configure Message of the Day for SSH (sourced function)
+customize # Perform further customizations (sourced function)
+
+# Clean up unused packages.
+msg_info "Cleaning up system"
+"$STD" apt-get -y autoremove
+"$STD" apt-get -y autoclean
+msg_ok "Cleaned up system"


### PR DESCRIPTION
- install/byparr-install.sh:
  - Corrected syntax error (extraneous 'fi') in error_handler.
- ct/byparr.sh:
  - Added error handling for pushd/popd failures (|| exit 1).
  - Added shellcheck directives to ignore warnings for variables (CT_TYPE, timezone, DISABLEIP6) sourced from build.func.
  - Added shellcheck directive to ignore constant expression warnings for VAAPI checks inherited from build.func structure.