### PR TITLE
Fix script execution issues when running directly from GitHub

### DIFF
--- a/ct/byparr.sh
+++ b/ct/byparr.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
-source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
 # Copyright (c) 2025 ColterD (Colter Dahlberg)
 # Author: ColterD (Colter Dahlberg)
 # License: MIT | https://github.com/ColterD/byparr-lxc/raw/main/LICENSE
 # Source: https://github.com/ThePhaseless/Byparr
 
-
+# Source the build.func file from community-scripts
+if ! source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func); then
+  echo "Error: Failed to source build.func from community-scripts"
+  exit 1
+fi
 
 APP="Byparr"
 var_tags="${var_tags:-media}"
@@ -17,10 +20,10 @@ var_version="${var_version:-12}"
 var_port="${var_port:-8191}"
 var_unprivileged="${var_unprivileged:-1}"
 
+# Display header and warnings
 header_info "$APP"
-# Display warning about community fork status
-msg_warning "THIS IS A COMMUNITY FORK by ColterD"
-msg_warning "Not yet part of official community-scripts"
+echo -e "\e[1;33m⚠️  THIS IS A COMMUNITY FORK by ColterD\e[0m"
+echo -e "\e[1;33m⚠️  Not yet part of official community-scripts\e[0m"
 sleep 2
 
 variables


### PR DESCRIPTION
This PR fixes issues encountered when running the script directly from GitHub:

- Add error handling for sourcing build.func
- Replace msg_warning with direct echo commands for the initial warnings
- Improve script robustness for direct execution

These changes should resolve the errors seen when running the script with:
```bash
bash -c "$(wget -qLO - https://raw.githubusercontent.com/ColterD/byparr-lxc/main/ct/byparr.sh)"
```